### PR TITLE
Majda/remove duplicate translation

### DIFF
--- a/Carnap-GHCJS/src/Carnap/GHCJS/Action/Translate.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Action/Translate.hs
@@ -88,7 +88,7 @@ activateTranslate w (Just (i,o,opts)) = do
                            ref <- newIORef False
                            let submit = submitTrans w opts i ref fs parser checker tests
                            btStatus <- createSubmitButton w bw submit opts
-                           setValue (castToHTMLInputElement i) (Just content)
+                           setValue (castToHTMLInputElement i) (Just "")
                            doOnce i input False $ liftIO $ btStatus Edited
                            setInnerHTML o (Just problem)
                            mpar@(Just par) <- getParentNode o               

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Action/Translate.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Action/Translate.hs
@@ -88,7 +88,10 @@ activateTranslate w (Just (i,o,opts)) = do
                            ref <- newIORef False
                            let submit = submitTrans w opts i ref fs parser checker tests
                            btStatus <- createSubmitButton w bw submit opts
+                           
+                           -- Initally set input box to empty
                            setValue (castToHTMLInputElement i) (Just "")
+                           
                            doOnce i input False $ liftIO $ btStatus Edited
                            setInnerHTML o (Just problem)
                            mpar@(Just par) <- getParentNode o               


### PR DESCRIPTION
* For Translation Interface.
* When rendering a question, the question text does not automatically appear within the solution entry box.
* The solution entry box is clear and ready to enter a solution.
* Link to Story: https://app.clickup.com/t/8678y7mcc 