### PR TITLE
CARNAP-123 -- Add Interface for Symbol Insertion

### DIFF
--- a/Carnap-Server/static/css/exercises.css
+++ b/Carnap-Server/static/css/exercises.css
@@ -92,6 +92,12 @@
     stroke:#A9B7C0;
 }
 
+.buttonWrapperConst button:nth-child(n) {
+    background: #D6DCE0;
+    border:1px solid #D6DCE0;
+    color:black;
+}
+
 @keyframes buttonHover {
     0% {
         background:#a9b7c0;


### PR DESCRIPTION
There is now a "Symbols" button in Translation exercises that toggles the view of buttons containing logical symbols. Upon clicking a button with a logical symbol, that symbol is automatically inserted into the answer input.

The amount of symbols depends on whether KooKMM-SL or KooKMM-QL is used, as KooKMM-QL contains extra symbols.