### PR TITLE
Add symbols buttons to derivation

### DIFF
--- a/Carnap-GHCJS/src/Carnap/GHCJS/Widget/ProofCheckBox.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Widget/ProofCheckBox.hs
@@ -45,7 +45,7 @@ data CheckerOptions = CheckerOptions { submit :: Maybe Button -- What's the subm
                                      , popout :: Bool -- Should the checker be able to be put in a new window?
                                      , hideNumbering :: Bool -- Should the checker hide the line numbering?
                                      , tests :: [String] --Should the checker apply tests to the conclusion?
-                                     -- , firstOrder :: Bool -- Should the checker use first-order logic?
+                                     , firstOrder :: Bool -- Should the checker use first-order logic?
                                      }
 
 optionsFromMap opts = CheckerOptions { submit = Nothing
@@ -78,7 +78,7 @@ optionsFromMap opts = CheckerOptions { submit = Nothing
                                       , popout = "popout" `elem` optlist
                                       , hideNumbering = "hideNumbering" `elem` optlist
                                       , tests = case M.lookup "tests" opts of Just s -> words s; Nothing -> []
-                                      -- , firstOrder = case M.lookup "system" opts of Just "firstOrder" -> True; Nothing -> False
+                                      , firstOrder = case M.lookup "system" opts of Just "firstOrder" -> True; Nothing -> False
                                       }
                 where optlist = case M.lookup "options" opts of Just s -> words s; Nothing -> []
 
@@ -149,10 +149,8 @@ checkerWith options updateres iog@(IOGoal i o g content _) w = do
            bw2 <- createButtonWrapperConst w o
            let createSymbolBtn symbol = createSymbolButton w bw2 symbol (insertTextClick i symbol)
            
-           -- case (M.lookup "transtype" options) of -- options does not contain transtype, fix this
-           --         (Just "prop") -> mapM createSymbolBtn ["→", "↔", "∧", "∨"]
-           --         _ -> mapM createSymbolBtn ["→", "↔", "∧", "∨", "∀", "∃", "≠"]
            mapM createSymbolBtn ["→", "↔", "∧", "∨"]
+           -- mapM createSymbolBtn (if firstOrder options then ["→", "↔", "∧", "∨", "∀", "∃", "≠"] else ["→", "↔", "∧", "∨"]) Currently super buggy
            symbolsPane <- createSymbolsPane w i
            appendChild symbolsPane (Just bw2)
 

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Widget/ProofCheckBox.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Widget/ProofCheckBox.hs
@@ -45,6 +45,7 @@ data CheckerOptions = CheckerOptions { submit :: Maybe Button -- What's the subm
                                      , popout :: Bool -- Should the checker be able to be put in a new window?
                                      , hideNumbering :: Bool -- Should the checker hide the line numbering?
                                      , tests :: [String] --Should the checker apply tests to the conclusion?
+                                     -- , firstOrder :: Bool -- Should the checker use first-order logic?
                                      }
 
 optionsFromMap opts = CheckerOptions { submit = Nothing
@@ -77,6 +78,7 @@ optionsFromMap opts = CheckerOptions { submit = Nothing
                                       , popout = "popout" `elem` optlist
                                       , hideNumbering = "hideNumbering" `elem` optlist
                                       , tests = case M.lookup "tests" opts of Just s -> words s; Nothing -> []
+                                      -- , firstOrder = case M.lookup "system" opts of Just "firstOrder" -> True; Nothing -> False
                                       }
                 where optlist = case M.lookup "options" opts of Just s -> words s; Nothing -> []
 
@@ -145,7 +147,7 @@ checkerWith options updateres iog@(IOGoal i o g content _) w = do
           
             -- Create symbols pane and add buttons to it
            bw2 <- createButtonWrapperConst w o
-           let createSymbolBtn symbol = createSymbolButton w bw2 symbol (insertSymbolClick i symbol)
+           let createSymbolBtn symbol = createSymbolButton w bw2 symbol (insertTextClick i symbol)
            
            -- case (M.lookup "transtype" options) of -- options does not contain transtype, fix this
            --         (Just "prop") -> mapM createSymbolBtn ["→", "↔", "∧", "∨"]
@@ -221,6 +223,12 @@ insertText f = do (Just t) <- target :: EventM HTMLTextAreaElement KeyboardEvent
                               insertion = f v pos
                           setValue t $ Just ( pre ++ insertion ++ post )
                           setSelectionEnd t (length (pre ++ insertion))
+
+insertTextClick :: Element -> String -> EventM Element MouseEvent ()
+insertTextClick textArea s = liftIO $ do
+    (Just val) <- getValue (castToHTMLTextAreaElement textArea)
+    let newValue = val ++ s
+    setValue (castToHTMLTextAreaElement textArea) (Just newValue)
 
 reindent :: EventM HTMLTextAreaElement KeyboardEvent ()
 reindent = insertText ws

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Widget/ProofCheckBox.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Widget/ProofCheckBox.hs
@@ -158,6 +158,9 @@ checkerWith options updateres iog@(IOGoal i o g content _) w = do
            showSymbolsBtn <- getShowSymbolsButton w symbolsPane
            appendChild bw (Just showSymbolsBtn)
 
+           -- Show symbols when right-click text area
+           addRightClickRevealer w symbolsPane i
+
            -- Add hidden symbols pane
            appendChild par (Just symbolsPane)
 

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Widget/ProofCheckBox.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Widget/ProofCheckBox.hs
@@ -78,7 +78,9 @@ optionsFromMap opts = CheckerOptions { submit = Nothing
                                       , popout = "popout" `elem` optlist
                                       , hideNumbering = "hideNumbering" `elem` optlist
                                       , tests = case M.lookup "tests" opts of Just s -> words s; Nothing -> []
-                                      , firstOrder = case M.lookup "system" opts of Just "firstOrder" -> True; Nothing -> False
+                                      , firstOrder = case M.lookup "system" opts of 
+                                            Just "firstOrder" -> True
+                                            _ -> False
                                       }
                 where optlist = case M.lookup "options" opts of Just s -> words s; Nothing -> []
 
@@ -149,8 +151,7 @@ checkerWith options updateres iog@(IOGoal i o g content _) w = do
            bw2 <- createButtonWrapperConst w o
            let createSymbolBtn symbol = createSymbolButton w bw2 symbol (insertTextClick i symbol)
            
-           mapM createSymbolBtn ["→", "↔", "∧", "∨"]
-           -- mapM createSymbolBtn (if firstOrder options then ["→", "↔", "∧", "∨", "∀", "∃", "≠"] else ["→", "↔", "∧", "∨"]) Currently super buggy
+           mapM createSymbolBtn (if firstOrder options then ["→", "↔", "∧", "∨", "∀", "∃", "≠"] else ["→", "↔", "∧", "∨"])
            symbolsPane <- createSymbolsPane w i
            appendChild symbolsPane (Just bw2)
 

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Widget/ProofCheckBox.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Widget/ProofCheckBox.hs
@@ -142,6 +142,25 @@ checkerWith options updateres iog@(IOGoal i o g content _) w = do
                                                    Nothing -> return ()
                    addListener bt click btlistener True
                _ -> return ()
+          
+            -- Create symbols pane and add buttons to it
+           bw2 <- createButtonWrapperConst w o
+           let createSymbolBtn symbol = createSymbolButton w bw2 symbol (insertSymbolClick i symbol)
+           
+           -- case (M.lookup "transtype" options) of -- options does not contain transtype, fix this
+           --         (Just "prop") -> mapM createSymbolBtn ["→", "↔", "∧", "∨"]
+           --         _ -> mapM createSymbolBtn ["→", "↔", "∧", "∨", "∀", "∃", "≠"]
+           mapM createSymbolBtn ["→", "↔", "∧", "∨"]
+           symbolsPane <- createSymbolsPane w i
+           appendChild symbolsPane (Just bw2)
+
+           -- Get and add Show Symbols button
+           showSymbolsBtn <- getShowSymbolsButton w symbolsPane
+           appendChild bw (Just showSymbolsBtn)
+
+           -- Add hidden symbols pane
+           appendChild par (Just symbolsPane)
+
            kblistener <- newListener $ updateWithValue (\s -> updateres options w ref s (g,fd))
            addListener i keyUp kblistener False
            when (popout options) $ do

--- a/Carnap-GHCJS/src/Lib.hs
+++ b/Carnap-GHCJS/src/Lib.hs
@@ -9,7 +9,7 @@ module Lib ( genericSendJSON, sendJSON, onEnter, onKey, doOnce, dispatchCustom, 
            , assignmentKey, initialize, mutate, initializeCallback, initCallbackObj
            , toCleanVal, popUpWith, spinnerSVG, doneButton, questionButton
            , exclaimButton, expandButton, createSubmitButton, createButtonWrapper, createButtonWrapperConst
-           , createSymbolsPane, getShowSymbolsButton, createSymbolButton, insertSymbolClick
+           , createSymbolsPane, getShowSymbolsButton, addRightClickRevealer, createSymbolButton, insertSymbolClick
            , maybeNodeListToList, trySubmit, inOpts, rewriteWith, setStatus, setSuccess, setFailure
            , ButtonStatus(..) , keyString) where
 
@@ -456,6 +456,16 @@ getShowSymbolsButton doc symbolsPane = do
     addListener button click clickListener False
 
     return button
+
+addRightClickRevealer :: Document -> Element -> Element -> IO ()
+addRightClickRevealer doc symbolsPane question = do
+
+    -- Toggle the display of the symbols pane only on right clicks
+    clickListener <- newListener $ liftIO $ do
+        (Just currentStyle) <- getAttribute symbolsPane "style"
+        let newStyle = if (fromString "none") `isInfixOf` currentStyle then "display: flex;" else "display: none;"
+        setAttribute symbolsPane "style" newStyle
+    addListener question contextMenu clickListener False
 
 createSymbolButton :: Document -> Element -> String -> EventM Element MouseEvent () -> IO Element
 createSymbolButton doc parent symbol clickHandler = do

--- a/Carnap-GHCJS/src/Lib.hs
+++ b/Carnap-GHCJS/src/Lib.hs
@@ -439,8 +439,8 @@ createButtonWrapperConst w o = do (Just bw) <- createElement w (Just "div")
 createSymbolsPane :: Document -> Element -> IO Element
 createSymbolsPane doc inputField = do
     (Just pane) <- createElement doc (Just "div")
-    setAttribute pane "id" "symbols-pane"
-    setAttribute pane "style" "display: none; position: absolute; border: 1px solid black; padding: 10px; background-color: white;"
+    setAttribute pane "class" "symbolsPane"
+    setAttribute pane "style" "display: none;"
 
     return pane
 
@@ -451,7 +451,7 @@ getShowSymbolsButton doc symbolsPane = do
     -- Toggle the display of the symbols pane
     clickListener <- newListener $ liftIO $ do
         (Just currentStyle) <- getAttribute symbolsPane "style"
-        let newStyle = if (fromString "none") `isInfixOf` currentStyle then "display: block;" else "display: none;"
+        let newStyle = if (fromString "none") `isInfixOf` currentStyle then "display: flex;" else "display: none;"
         setAttribute symbolsPane "style" newStyle
     addListener button click clickListener False
 

--- a/Carnap-Server/static/css/exercises.css
+++ b/Carnap-Server/static/css/exercises.css
@@ -21,6 +21,10 @@
 
 .exercise > span:nth-child(2) { right:10pt;}
 
+.buttonWrapper {
+    width: fit-content;
+}
+
 .buttonWrapper button {
     height:2em;
     margin:0px;
@@ -64,6 +68,21 @@
     stroke:white;
 }
 
+.buttonWrapperConst button:nth-child(n) {
+    background: #D6DCE0;
+    border:1px solid #D6DCE0;
+    color:black;
+    width: 28px;
+    height: 28px;
+}
+
+.symbolsPane {
+    min-width:100%;
+    float: inline-end;
+    margin-top: 5px;
+    justify-content: center;
+}
+
 .buttonWrapper button:hover,
 .buttonWrapper button[data-carnap-exercise-status="submitted"]
 {
@@ -90,12 +109,6 @@
 .buttonWrapper button[data-carnap-exercise-status="submitted"] svg .filler {
     fill:#A9B7C0;
     stroke:#A9B7C0;
-}
-
-.buttonWrapperConst button:nth-child(n) {
-    background: #D6DCE0;
-    border:1px solid #D6DCE0;
-    color:black;
 }
 
 @keyframes buttonHover {
@@ -183,8 +196,7 @@
 
 /* This is what will need to be the locus of responsive resizing */
 [data-carnap-type="proofchecker"] {
-    display:inline-block;
-    vertical-align:top;
+    display:block;
     position: relative;
     width:500px;
     min-height:110pt;


### PR DESCRIPTION
Now every derivation question has a "Show Symbols" button that, when clicked, gives a pane of symbols that can be clicked to insert them into the derivation.

Right-clicking the text area also toggles the appearance of the symbols pane.