### PR TITLE
Implemented KooKMM-BASIC

### DIFF
--- a/Carnap/src/Carnap/Languages/PurePropositional/Logic.hs
+++ b/Carnap/src/Carnap/Languages/PurePropositional/Logic.hs
@@ -2,7 +2,7 @@
 module Carnap.Languages.PurePropositional.Logic 
     ( PropSequentCalc
     , parsePropLogic, PropLogic, propCalc, propCalcStrict
-    , parseMontagueSC, MontagueSC, montagueSCCalc, kooSLCalc
+    , parseMontagueSC, MontagueSC, montagueSCCalc, kooSLCalc, kooSLBasicCalc
     , parseLogicBookSD, LogicBookSD, logicBookSDCalc
     , parseLogicBookSDPlus,  LogicBookSDPlus, logicBookSDPlusCalc
     , parseHowardSnyderSL, HowardSnyderSL, howardSnyderSLCalc
@@ -92,6 +92,7 @@ ofPropSys f sys | sys == "LogicBookSD"                   = Just $ f logicBookSDC
                 | sys == "johnsonSL"                     = Just $ f allenSLCalc
                 | sys == "johnsonSLPlus"                 = Just $ f allenSLPlusCalc
                 | sys == "KooKMM-SL"                     = Just $ f kooSLCalc
+                | sys == "KooKMM-BASIC"                  = Just $ f kooSLBasicCalc
                 | sys == "landeProp"                     = Just $ f landePropCalc
                 | sys == "lemmonProp"                    = Just $ f lemmonPropCalc
                 | sys == "magnusSL"                      = Just $ f magnusSLCalc

--- a/Carnap/src/Carnap/Languages/PurePropositional/Logic/KooSL.hs
+++ b/Carnap/src/Carnap/Languages/PurePropositional/Logic/KooSL.hs
@@ -1,6 +1,6 @@
 {-#LANGUAGE FlexibleContexts, FlexibleInstances, MultiParamTypeClasses #-}
 module Carnap.Languages.PurePropositional.Logic.KooSL
-    (parseKooSLProof, kooSLCalc, kooSLNotation, KooSL, parseKooSL) where
+    (parseKooSLProof, kooSLCalc, kooSLNotation, KooSL, parseKooSL, kooSLBasicCalc) where
 
 import Data.Map as M (lookup, Map)
 import Text.Parsec
@@ -184,6 +184,35 @@ parseKooSL rtc = do r <- choice (map (try . string) ["AS","PR","MP","MTP","MT","
                                         Just r  -> return [DER r]
                                         Nothing -> parserFail "Looks like you're citing a derived rule that doesn't exist"
 
+parseKooSLBasic :: RuntimeDeductionConfig PurePropLexicon (Form Bool) -> Parsec String u [KooSL]
+parseKooSLBasic rtc = do r <- choice (map (try . string) ["AS","PR","MP","MTP","MT","DD","DNE","DNI", "DN", "SC", "S", "ADJ",  "ADD" , "BC", "CB", "CDJ", "CD", "ID", "R", "TR", "NC", "NB", "DM", "MC", "D-"])
+                    case r of
+                        "AS"   -> return [AS]
+                        "PR"   -> return [PR (problemPremises rtc)]
+                        "MP"   -> return [MP]
+                        "MT"   -> return [MT]
+                        "DD"   -> return [DD]
+                        "DNE"  -> return [DNE]
+                        "DNI"  -> return [DNI]
+                        "DN"   -> return [DNE,DNI]
+                        "CD"   -> return [CP1,CP2]
+                        "ID"   -> return [ID1,ID2,ID3,ID4,ID5,ID6,ID7,ID8]
+                        "ADJ"  -> return [ADJ]
+                        "S"    -> return [S1, S2]
+                        "ADD"  -> return [ADD1, ADD2]
+                        "MTP"  -> return [MTP1, MTP2]
+                        "R"    -> return [R]
+                        "TR"   -> return [TR1, TR2]
+                        "SC"   -> return [SC1, SC2, SC3]
+                        "D-" -> do  rn <- many1 upper
+                                    case M.lookup rn (derivedRules rtc) of
+                                        Just r  -> return [DER r]
+                                        Nothing -> parserFail "Looks like you're citing a derived rule that doesn't exist"
+
+parseKooSLBasicProof :: RuntimeDeductionConfig PurePropLexicon (Form Bool) 
+                     -> String -> [DeductionLine KooSL PurePropLexicon (Form Bool)]
+parseKooSLBasicProof rtc = toDeductionMontague (parseKooSLBasic rtc) (kooSLFormulaParser kooOpts)
+
 parseKooSLProof :: RuntimeDeductionConfig PurePropLexicon (Form Bool) 
                      -> String -> [DeductionLine KooSL PurePropLexicon (Form Bool)]
 parseKooSLProof rtc = toDeductionMontague (parseKooSL rtc) (kooSLFormulaParser kooOpts)
@@ -200,6 +229,16 @@ kooSLNotation = map replace
 kooSLCalc = mkNDCalc
     { ndRenderer = MontagueStyle
     , ndParseProof = parseKooSLProof
+    , ndProcessLine = processLineMontague
+    , ndProcessLineMemo = Nothing
+    , ndNotation = kooSLNotation
+    , ndParseForm = (kooSLFormulaParser kooOpts)
+    , ndParseSeq = parseSeqOver (kooSLFormulaParser kooOpts)
+    } 
+
+kooSLBasicCalc = mkNDCalc
+    { ndRenderer = MontagueStyle
+    , ndParseProof = parseKooSLBasicProof
     , ndProcessLine = processLineMontague
     , ndProcessLineMemo = Nothing
     , ndNotation = kooSLNotation

--- a/Carnap/src/Carnap/Languages/PurePropositional/Logic/KooSL.hs
+++ b/Carnap/src/Carnap/Languages/PurePropositional/Logic/KooSL.hs
@@ -185,29 +185,29 @@ parseKooSL rtc = do r <- choice (map (try . string) ["AS","PR","MP","MTP","MT","
                                         Nothing -> parserFail "Looks like you're citing a derived rule that doesn't exist"
 
 parseKooSLBasic :: RuntimeDeductionConfig PurePropLexicon (Form Bool) -> Parsec String u [KooSL]
-parseKooSLBasic rtc = do r <- choice (map (try . string) ["AS","PR","MP","MTP","MT","DD","DNE","DNI", "DN", "SC", "S", "ADJ",  "ADD" , "BC", "CB", "CDJ", "CD", "ID", "R", "TR", "NC", "NB", "DM", "MC", "D-"])
-                    case r of
-                        "AS"   -> return [AS]
-                        "PR"   -> return [PR (problemPremises rtc)]
-                        "MP"   -> return [MP]
-                        "MT"   -> return [MT]
-                        "DD"   -> return [DD]
-                        "DNE"  -> return [DNE]
-                        "DNI"  -> return [DNI]
-                        "DN"   -> return [DNE,DNI]
-                        "CD"   -> return [CP1,CP2]
-                        "ID"   -> return [ID1,ID2,ID3,ID4,ID5,ID6,ID7,ID8]
-                        "ADJ"  -> return [ADJ]
-                        "S"    -> return [S1, S2]
-                        "ADD"  -> return [ADD1, ADD2]
-                        "MTP"  -> return [MTP1, MTP2]
-                        "R"    -> return [R]
-                        "TR"   -> return [TR1, TR2]
-                        "SC"   -> return [SC1, SC2, SC3]
-                        "D-" -> do  rn <- many1 upper
-                                    case M.lookup rn (derivedRules rtc) of
-                                        Just r  -> return [DER r]
-                                        Nothing -> parserFail "Looks like you're citing a derived rule that doesn't exist"
+parseKooSLBasic rtc =   (do r <- choice (map (try . string) ["AS","PR","MP","MTP","MT","DD","DNE","DNI", "DN", "SC", "S", "ADJ",  "ADD" , "CD", "ID", "R", "TR", "D-"])
+                            case r of 
+                                "AS"   -> return [AS]
+                                "PR"   -> return [PR (problemPremises rtc)]
+                                "MP"   -> return [MP]
+                                "MT"   -> return [MT]
+                                "DD"   -> return [DD]
+                                "DNE"  -> return [DNE]
+                                "DNI"  -> return [DNI]
+                                "DN"   -> return [DNE,DNI]
+                                "CD"   -> return [CP1,CP2]
+                                "ID"   -> return [ID1,ID2,ID3,ID4,ID5,ID6,ID7,ID8]
+                                "ADJ"  -> return [ADJ]
+                                "S"    -> return [S1, S2]
+                                "ADD"  -> return [ADD1, ADD2]
+                                "MTP"  -> return [MTP1, MTP2]
+                                "R"    -> return [R]
+                                "TR"   -> return [TR1, TR2]
+                                "SC"   -> return [SC1, SC2, SC3]
+                                "D-" -> do  rn <- many1 upper
+                                            case M.lookup rn (derivedRules rtc) of
+                                                Just r  -> return [DER r]
+                                                Nothing -> parserFail "Looks like you're citing a derived rule that doesn't exist")
 
 parseKooSLBasicProof :: RuntimeDeductionConfig PurePropLexicon (Form Bool) 
                      -> String -> [DeductionLine KooSL PurePropLexicon (Form Bool)]


### PR DESCRIPTION
New Koo languages that is the same as KooKMM-SL without the following rules: BC, CB, CDJ, NC, NB, DM, MC